### PR TITLE
fix brightness of m5core2 screen

### DIFF
--- a/components/axp192/axp192.cpp
+++ b/components/axp192/axp192.cpp
@@ -207,7 +207,7 @@ void AXP192Component::UpdateBrightness()
       case AXP192_M5CORE2:
       {
         uint8_t buf = Read8bit( 0x27 );
-        Write1Byte( 0x27 , ((buf & 0x0f) | (ubri << 4)) );
+		Write1Byte( 0x27 , ((buf & 0x80) | (ubri << 3)) );
       }
     }
 }

--- a/sample-config/m5core2.yaml
+++ b/sample-config/m5core2.yaml
@@ -39,6 +39,7 @@ sensor:
     address: 0x34
     i2c_id: bus_a
     update_interval: 30s
+	brightness: 75%
     battery_level:
       name: "${upper_devicename} Battery Level"
       id: "${devicename}_batterylevel"


### PR DESCRIPTION
m5core2 uses DC-DC3 to control brightness rather than using LDO2. DC-DC3 is controlled by the 7 least significant bits in the 0x27 register; the most significant bit is reserved. As a result the brightness value shifts left 3 places rather than 4. in order to set the register I read the entire byte, logical AND with 0x80 to clear all bits except the reserved bit, logical OR with the shifted brightness value.

added brightness to the sample m5core2 config