### PR TITLE
Bugfix: Add breaks to switch/case statements. Format: Replace tabs with four spaces. Remove trailing spaces. 

### DIFF
--- a/components/axp192/axp192.cpp
+++ b/components/axp192/axp192.cpp
@@ -13,11 +13,13 @@ void AXP192Component::setup()
     case AXP192_M5STICKC:
     {
         begin(false, false, false, false, false);
+        break;
     }
     case AXP192_M5CORE2:
     {
         // disable LDO3 Vibration
         begin(false, true, false, false, false);
+        break;
     }
     case AXP192_M5TOUGH:
     {
@@ -30,7 +32,8 @@ void AXP192Component::setup()
 
             // Reboot the ESP with the axp initialised
             ESP.restart();
-    }
+        }
+        break;
     }
   }
 }
@@ -69,6 +72,7 @@ void AXP192Component::begin(bool disableLDO2, bool disableLDO3, bool disableRTC,
     {
         // Set LDO2 & LDO3(TFT_LED & TFT) 3.0V
         Write1Byte(0x28, 0xcc);	
+        break;
     }
     case AXP192_M5CORE2:
     {
@@ -76,6 +80,7 @@ void AXP192Component::begin(bool disableLDO2, bool disableLDO3, bool disableRTC,
         Write1Byte(0x27, 0xcc);	
         // Set LDO2 & LDO3(TFT_LED & TFT) 3.0V
         Write1Byte(0x28, 0xcc);	
+        break;
     }
     case AXP192_M5TOUGH:
     {
@@ -83,6 +88,7 @@ void AXP192Component::begin(bool disableLDO2, bool disableLDO3, bool disableRTC,
         Write1Byte(0x27, 0xcc);	
         // Set LDO2 & LDO3(TFT_LED & TFT) 3.0V
         Write1Byte(0x28, 0xcc);	
+        break;
     }
   }
 
@@ -226,16 +232,19 @@ void AXP192Component::UpdateBrightness()
       {
         uint8_t buf = Read8bit( 0x28 );
         Write1Byte( 0x28 , ((buf & 0x0f) | (ubri << 4)) );
+        break;
       }
       case AXP192_M5CORE2:
       {
         uint8_t buf = Read8bit( 0x27 );
-	Write1Byte( 0x27 , ((buf & 0x80) | (ubri << 3)) );
+	    Write1Byte( 0x27 , ((buf & 0x80) | (ubri << 3)) );
+        break;
       }
       case AXP192_M5TOUGH:
       {
         uint8_t buf = Read8bit( 0x27 );
-	Write1Byte( 0x27 , ((buf & 0x80) | (ubri << 3)) );
+	    Write1Byte( 0x27 , ((buf & 0x80) | (ubri << 3)) );
+        break;
       }
     }
 }

--- a/components/axp192/axp192.cpp
+++ b/components/axp192/axp192.cpp
@@ -7,7 +7,7 @@ namespace esphome {
 namespace axp192 {
 
 static const char *TAG = "axp192.sensor";
-void AXP192Component::setup() 
+void AXP192Component::setup()
 {
   switch (this->model_) {
     case AXP192_M5STICKC:
@@ -66,35 +66,35 @@ void AXP192Component::update() {
 
 
 void AXP192Component::begin(bool disableLDO2, bool disableLDO3, bool disableRTC, bool disableDCDC1, bool disableDCDC3)
-{  
+{
   switch (this->model_) {
     case AXP192_M5STICKC:
     {
         // Set LDO2 & LDO3(TFT_LED & TFT) 3.0V
-        Write1Byte(0x28, 0xcc);	
+        Write1Byte(0x28, 0xcc);
         break;
     }
     case AXP192_M5CORE2:
     {
         // Set DCDC3 (TFT_LED & TFT) 3.0V
-        Write1Byte(0x27, 0xcc);	
+        Write1Byte(0x27, 0xcc);
         // Set LDO2 & LDO3(TFT_LED & TFT) 3.0V
-        Write1Byte(0x28, 0xcc);	
+        Write1Byte(0x28, 0xcc);
         break;
     }
     case AXP192_M5TOUGH:
     {
         // Set DCDC3 (TFT_LED & TFT) 3.0V
-        Write1Byte(0x27, 0xcc);	
+        Write1Byte(0x27, 0xcc);
         // Set LDO2 & LDO3(TFT_LED & TFT) 3.0V
-        Write1Byte(0x28, 0xcc);	
+        Write1Byte(0x28, 0xcc);
         break;
     }
   }
 
     // Set ADC sample rate to 200hz
     Write1Byte(0x84, 0b11110010);
-    
+
     // Set ADC to All Enable
     Write1Byte(0x82, 0xff);
 
@@ -107,15 +107,15 @@ void AXP192Component::begin(bool disableLDO2, bool disableLDO3, bool disableRTC,
     if(disableLDO2) buf &= ~(1<<2);
     if(disableDCDC3) buf &= ~(1<<1);
     if(disableDCDC1) buf &= ~(1<<0);
-    Write1Byte(0x12, buf);	
-    
+    Write1Byte(0x12, buf);
+
     // 128ms power on, 4s power off
     Write1Byte(0x36, 0x0C);
 
     if(!disableRTC)
     {
         // Set RTC voltage to 3.3V
-        Write1Byte(0x91, 0xF0);	
+        Write1Byte(0x91, 0xF0);
 
         // Set GPIO0 to LDO
         Write1Byte(0x90, 0x02);
@@ -126,13 +126,13 @@ void AXP192Component::begin(bool disableLDO2, bool disableLDO3, bool disableRTC,
 
     // Set temperature protection
     Write1Byte(0x39, 0xfc);
-    
-    // Enable RTC BAT charge 
+
+    // Enable RTC BAT charge
     Write1Byte(0x35, 0xa2 & (disableRTC ? 0x7F : 0xFF));
-    
+
     // Enable bat detection
     Write1Byte(0x32, 0x46);
-	
+
 }
 
 void AXP192Component::Write1Byte( uint8_t Addr ,  uint8_t Data )
@@ -222,8 +222,8 @@ void AXP192Component::UpdateBrightness()
     const uint8_t c_min = 7;
     const uint8_t c_max = 12;
     auto ubri = c_min + static_cast<uint8_t>(brightness_ * (c_max - c_min));
-    
-    if (ubri > c_max) 
+
+    if (ubri > c_max)
     {
         ubri = c_max;
     }
@@ -237,20 +237,20 @@ void AXP192Component::UpdateBrightness()
       case AXP192_M5CORE2:
       {
         uint8_t buf = Read8bit( 0x27 );
-	    Write1Byte( 0x27 , ((buf & 0x80) | (ubri << 3)) );
+        Write1Byte( 0x27 , ((buf & 0x80) | (ubri << 3)) );
         break;
       }
       case AXP192_M5TOUGH:
       {
         uint8_t buf = Read8bit( 0x27 );
-	    Write1Byte( 0x27 , ((buf & 0x80) | (ubri << 3)) );
+        Write1Byte( 0x27 , ((buf & 0x80) | (ubri << 3)) );
         break;
       }
     }
 }
 
 bool AXP192Component::GetBatState()
-{	
+{
     if( Read8bit(0x01) | 0x20 )
         return true;
     else
@@ -262,7 +262,7 @@ uint8_t AXP192Component::GetBatData()
     return Read8bit(0x75);
 }
 //---------coulombcounter_from_here---------
-//enable: void EnableCoulombcounter(void); 
+//enable: void EnableCoulombcounter(void);
 //disable: void DisableCOulombcounter(void);
 //stop: void StopCoulombcounter(void);
 //clear: void ClearCoulombcounter(void);
@@ -417,7 +417,7 @@ void AXP192Component::SetSleep(void)
 
 // -- sleep
 void AXP192Component::DeepSleep(uint64_t time_in_us)
-{ 
+{
     SetSleep();
     esp_sleep_enable_ext0_wakeup((gpio_num_t)37, 0 /* LOW */);
     if (time_in_us > 0)
@@ -448,7 +448,7 @@ void AXP192Component::LightSleep(uint64_t time_in_us)
 uint8_t AXP192Component::GetBtnPress()
 {
     uint8_t state = Read8bit(0x46);
-    if(state) 
+    if(state)
     {
         Write1Byte( 0x46 , 0x03 );
     }
@@ -617,7 +617,7 @@ std::string AXP192Component::GetStartupReason() {
       return "ESP_SLEEP_WAKEUP_UART";
     return std::string{"WAKEUP_UNKNOWN_REASON"};
   }
-	
+
   if (reset_reason == ESP_RST_UNKNOWN)
     return "ESP_RST_UNKNOWN";
   if (reset_reason == ESP_RST_POWERON)
@@ -638,7 +638,7 @@ std::string AXP192Component::GetStartupReason() {
     return "ESP_RST_SDIO";
   return std::string{"RESET_UNKNOWN_REASON"};
 }
-	
+
 }
 }
 

--- a/components/axp192/axp192.h
+++ b/components/axp192/axp192.h
@@ -43,7 +43,7 @@ public:
 
 private:
     static std::string GetStartupReason();
-  
+
 protected:
     sensor::Sensor *batterylevel_sensor_;
     float brightness_{1.0f};
@@ -53,28 +53,28 @@ protected:
     /** M5 Stick Values
      * LDO2: Display backlight
      * LDO3: Display Control
-     * RTC: Don't set GPIO1 as LDO  
+     * RTC: Don't set GPIO1 as LDO
      * DCDC1: Main rail. When not set the controller shuts down.
      * DCDC3: Use unknown
      ***********************
      * M5Stack Core2 Values
      * LDO2: ILI9342C PWR (Display)
      * LD03: Vibration Motor
-     */ 
+     */
 
     void  begin(bool disableLDO2 = false, bool disableLDO3 = false, bool disableRTC = false, bool disableDCDC1 = false, bool disableDCDC3 = false);
     void  UpdateBrightness();
     bool  GetBatState();
     uint8_t  GetBatData();
-  
+
     void  EnableCoulombcounter(void);
     void  DisableCoulombcounter(void);
     void  StopCoulombcounter(void);
     void  ClearCoulombcounter(void);
     uint32_t GetCoulombchargeData(void);
     uint32_t GetCoulombdischargeData(void);
-    float GetCoulombData(void); 
-    
+    float GetCoulombData(void);
+
     uint16_t GetVbatData(void) __attribute__((deprecated));
     uint16_t GetIchargeData(void) __attribute__((deprecated));
     uint16_t GetIdischargeData(void) __attribute__((deprecated));
@@ -106,15 +106,15 @@ protected:
     float GetAPSVoltage();
     float GetBatCoulombInput();
     float GetBatCoulombOut();
-    uint8_t GetWarningLevel(void);	
+    uint8_t GetWarningLevel(void);
     void SetCoulombClear();
     void SetLDO2( bool State );
     void SetLDO3( bool State );
     void SetAdcState(bool State);
-    
+
     void PowerOff();
 
-    
+
     void Write1Byte( uint8_t Addr ,  uint8_t Data );
     uint8_t Read8bit( uint8_t Addr );
     uint16_t Read12Bit( uint8_t Addr);
@@ -123,7 +123,7 @@ protected:
     uint32_t Read24bit( uint8_t Addr );
     uint32_t Read32bit( uint8_t Addr );
     void ReadBuff( uint8_t Addr , uint8_t Size , uint8_t *Buff );
-}; 
+};
 
 }
 }


### PR DESCRIPTION
See there are 2 commits in this PR. The first fixes the bug, the second performs some formatting fixes.

The Bug:

The switch/cases will execute the code in all following case statements until reaching a `break;`.

In the setup function, the M5CORE2 will execute the begin() statement which disables LDO3. However, because there is no break statement, the M5CORE2 will continue through to the next case statement and execute begin() for the M5TOUG. This will re-enable LDO3. When LDO3 is enabled on the M5CORE2, the vibration sensor is turned on.

How to verify this bug yourself:
1. Start with an M5 device.
2. Move the `case` statements around so that your M5 device is at the top of the list.
3. Insert ESP_LOGD entries in each `case` statement so you can see which one (or more) gets executed.
4. Flash your M5 using your modified library.
6. See that the `case` statements for each device are run sequentially, despite having your M5 device set.
