### PR TITLE
add charging binary sensor

### DIFF
--- a/components/axp192/axp192.cpp
+++ b/components/axp192/axp192.cpp
@@ -61,6 +61,13 @@ void AXP192Component::update() {
       this->batterylevel_sensor_->publish_state(batterylevel);
     }
 
+    if (this->charging_sensor_ != nullptr) {
+        bool battery_state = GetBatState();
+      bool charging = GetChargingState();
+      ESP_LOGD(TAG, "Got Charging=%d state=%d", charging, battery_state);
+      this->charging_sensor_->publish_state(charging);
+    }
+
     UpdateBrightness();
 }
 
@@ -252,6 +259,15 @@ void AXP192Component::UpdateBrightness()
 bool AXP192Component::GetBatState()
 {
     if( Read8bit(0x01) | 0x20 )
+        return true;
+    else
+        return false;
+}
+
+bool AXP192Component::GetChargingState()
+{
+    // reading 0x01 bit 6
+    if( (Read8bit(0x00) >> 5) & 0x01 )
         return true;
     else
         return false;

--- a/components/axp192/axp192.cpp
+++ b/components/axp192/axp192.cpp
@@ -266,7 +266,7 @@ bool AXP192Component::GetBatState()
 
 bool AXP192Component::GetChargingState()
 {
-    // reading 0x01 bit 6
+    // reading 0x00 bit 6
     if( (Read8bit(0x00) >> 5) & 0x01 )
         return true;
     else

--- a/components/axp192/axp192.h
+++ b/components/axp192/axp192.h
@@ -3,6 +3,7 @@
 
 #include "esphome/core/component.h"
 #include "esphome/components/sensor/sensor.h"
+#include "esphome/components/binary_sensor/binary_sensor.h"
 #include "esphome/components/i2c/i2c.h"
 
 namespace esphome {
@@ -31,6 +32,7 @@ enum AXP192Model {
 class AXP192Component : public PollingComponent, public i2c::I2CDevice {
 public:
   void set_batterylevel_sensor(sensor::Sensor *batterylevel_sensor) { batterylevel_sensor_ = batterylevel_sensor; }
+  void set_charging_sensor(binary_sensor::BinarySensor *charging_sensor) { charging_sensor_ = charging_sensor; }
   void set_brightness(float brightness) { brightness_ = brightness; }
   void set_model(AXP192Model model) { this->model_ = model; }
 
@@ -46,6 +48,7 @@ private:
 
 protected:
     sensor::Sensor *batterylevel_sensor_;
+    binary_sensor::BinarySensor *charging_sensor_;
     float brightness_{1.0f};
     float curr_brightness_{-1.0f};
     AXP192Model model_;
@@ -65,6 +68,7 @@ protected:
     void  begin(bool disableLDO2 = false, bool disableLDO3 = false, bool disableRTC = false, bool disableDCDC1 = false, bool disableDCDC3 = false);
     void  UpdateBrightness();
     bool  GetBatState();
+    bool  GetChargingState();
     uint8_t  GetBatData();
 
     void  EnableCoulombcounter(void);

--- a/components/axp192/sensor.py
+++ b/components/axp192/sensor.py
@@ -1,8 +1,10 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
-from esphome.components import i2c, sensor
+from esphome.components import i2c, sensor, binary_sensor
 from esphome.const import CONF_ID,\
     CONF_BATTERY_LEVEL, CONF_BRIGHTNESS, UNIT_PERCENT, ICON_BATTERY, CONF_MODEL
+
+CONF_CHARGING = "charging"
 
 DEPENDENCIES = ['i2c']
 
@@ -27,6 +29,7 @@ CONFIG_SCHEMA = cv.Schema({
             accuracy_decimals=1,
             icon=ICON_BATTERY,
         ),
+    cv.Optional(CONF_CHARGING): binary_sensor.binary_sensor_schema(),
     cv.Optional(CONF_BRIGHTNESS, default=1.0): cv.percentage,
 }).extend(cv.polling_component_schema('60s')).extend(i2c.i2c_device_schema(0x77))
 
@@ -41,6 +44,11 @@ def to_code(config):
         conf = config[CONF_BATTERY_LEVEL]
         sens = yield sensor.new_sensor(conf)
         cg.add(var.set_batterylevel_sensor(sens))
+
+    if CONF_CHARGING in config:
+        conf = config[CONF_CHARGING]
+        sens = yield binary_sensor.new_binary_sensor(conf)
+        cg.add(var.set_charging_sensor(sens))
 
     if CONF_BRIGHTNESS in config:
         conf = config[CONF_BRIGHTNESS]


### PR DESCRIPTION
added a binary sensor to indicate if the battery is charging

```yaml
sensor:
  - platform: axp192
    model: M5STICKC
    id: axp_192
    address: 0x34
    i2c_id: bus_a
    update_interval: 1s
    brightness: 1.0
    charging:
      name: "${friendly_name} Charging"
      id: axp_charger
    battery_level:
      name: "${friendly_name} Battery Percent"
      id: batteryPercent
```