### PR TITLE
Add esp-idf framework compatibility

### DIFF
--- a/components/axp192/axp192.cpp
+++ b/components/axp192/axp192.cpp
@@ -1,7 +1,7 @@
 #include "axp192.h"
 #include "esphome/core/log.h"
 #include "esp_sleep.h"
-#include <Esp.h>
+#include "esp_system.h"
 
 namespace esphome {
 namespace axp192 {
@@ -31,7 +31,7 @@ void AXP192Component::setup()
             ESP_LOGD(TAG, "First power on, restarting ESP...");
 
             // Reboot the ESP with the axp initialised
-            ESP.restart();
+            esp_restart();
         }
         break;
     }


### PR DESCRIPTION
- Replace Arduino-specific Esp.h with esp_system.h
- Replace ESP.restart() with esp_restart()
- Component now works with both Arduino and esp-idf frameworks

This is especially usefull if you want your m5stack to also use bluetooth simultaneously with wifi, as this is much better supported in es-pidf. 